### PR TITLE
Dev sam optimize product search

### DIFF
--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -26,7 +26,7 @@ class ProductList(ListAPIView):
 
     def get_queryset(self):
         query = self.request.GET.get('contains', '')
-        return Products.objects.filter(name__icontains=query).order_by('id')
+        return Products.objects.filter(name__contains=query).order_by('id')
 
 # Get pending tasks in order of nearest due date
 @permission_classes([IsAuthenticated])


### PR DESCRIPTION
* Made product search query case-sensitive to improve performance

I did some research and found out the reason our product search endpoint is so slow is that case insensitive querying is MUCH more expensive than standard querying because it can't make use of database indexes.
Ideally, we would have case insensitive search, but it's not worth the performance dip, and it doesn't make that big of a difference